### PR TITLE
Add OIDC token support

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ jobs:
 ## Inputs
 
 - `version` (optional) - A string representing the version of the Depot CLI to install (e.g. `1.2.3`). The default value is `latest` which will install the latest available version. Can also specify a semver version range selector (e.g. `0.x.x`).
+- `oidc` (optional) - A boolean value indicating, if `true` the action will authenticate with the Depot API using GitHub Actions OIDC and set the `DEPOT_TOKEN` environment variable for future steps. This is typically not needed if you are using the `depot/build-push-action` action. The default value is `false`.
 
 ## Authentication
 

--- a/action.yml
+++ b/action.yml
@@ -14,3 +14,9 @@ inputs:
       the latest version for the target platform will be installed. Example: "0.0.2".
     default: latest
     required: false
+  oidc:
+    description: |-
+      If set to true, the action will authenticate with the Depot API using OIDC
+      and save the returned token as environment a `DEPOT_TOKEN` environment variable.
+    default: 'false'
+    required: false


### PR DESCRIPTION
Allows the action to exchange an OIDC token for a Depot API token and persist it as `DEPOT_TOKEN` for future steps. This is typically not needed if you are using `depot/build-push-action`.