### PR TITLE
Use `dl.depot.dev` to fetch CLI release information

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -5472,7 +5472,7 @@ async function run() {
     }
 }
 async function resolveVersion(version) {
-    const res = await client.get(`https://depot.dev/api/cli/release/${process.platform}/${process.arch}/${version}`);
+    const res = await client.get(`https://dl.depot.dev/cli/release/${process.platform}/${process.arch}/${version}`);
     const body = await res.readBody();
     const response = JSON.parse(body);
     if (!response.ok)

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,7 +45,7 @@ async function run() {
 }
 
 async function resolveVersion(version: string) {
-  const res = await client.get(`https://depot.dev/api/cli/release/${process.platform}/${process.arch}/${version}`)
+  const res = await client.get(`https://dl.depot.dev/cli/release/${process.platform}/${process.arch}/${version}`)
   const body = await res.readBody()
   const response: ApiResponse = JSON.parse(body)
 


### PR DESCRIPTION
We have a new `dl.depot.dev` service just for fetching CLI release information. ✨ 