### PR TITLE
Update to node20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -5,7 +5,7 @@ branding:
   icon: package
   color: gray-dark
 runs:
-  using: node16
+  using: node20
   main: dist/index.js
 inputs:
   version:


### PR DESCRIPTION
node16 is being deprecated. This should address #11.