### PR TITLE
ci: verify dist is up to date on pull requests

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -1,0 +1,41 @@
+name: Check dist
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  check-dist:
+    name: Build and compare dist
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build dist
+        run: pnpm build
+
+      - name: Verify dist is up to date
+        run: |
+          git add --all -- dist
+          git diff --cached --exit-code -- dist

--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -14,17 +14,17 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 10
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 24
           cache: pnpm


### PR DESCRIPTION
## Summary

- add a pull request workflow that rebuilds dist on every new PR commit
- fail when rebuilt artifacts differ from the committed dist
- restrict workflow permissions and avoid persisted checkout credentials

## Testing

- pnpm install --frozen-lockfile
- pnpm fmt:check
- pnpm type-check
- pnpm build
- generated dist comparison
- workflow YAML syntax validation

Linear: https://linear.app/depot/issue/DEP-6109/add-pr-check-to-verify-setup-action-dist-is-up-to-date